### PR TITLE
Support more than two digits of each unit

### DIFF
--- a/src/countdown/__main__.py
+++ b/src/countdown/__main__.py
@@ -17,11 +17,11 @@ DURATION_RE = re.compile(
     r"""
     ^
     (?:                 # Optional minutes
-        ( \d{1,2} )     # D or DD
+        ( \d+ )         # one or more digits
         m               # "m"
     )?
     (?:                 # Optional seconds
-        ( \d{1,2} )     # D or DD
+        ( \d+ )         # one or more digits
         s               # "s"
     )?
     $


### PR DESCRIPTION
Hello! Thanks for this very useful timer!

I've been using this to display the time remaining in exams for [my class](https://www.cs.cornell.edu/courses/cs4110/2024sp/) this semester. It worked great for both of the preliminary exams because the duration was 50 minutes. But the final exam, which is happening now, is 150 minutes—and it looks like the regexes for parsing durations only allow up to 2 digits (and no hours). So here's a small change that allows both seconds and minutes to be one or more digits. For this exam, for example, I can now do `countdown 150m`.

Let me know if there's anything else that would be useful in this PR!